### PR TITLE
Explicitly set spellcheck to false

### DIFF
--- a/prod/conf/solrconfig.xml
+++ b/prod/conf/solrconfig.xml
@@ -3,9 +3,9 @@
   <!-- NOTE: various comments and unused configuration possibilities have been purged
      from this file.  Please refer to http://wiki.apache.org/solr/SolrConfigXml,
      as well as the default solrconfig file included with Solr -->
-  
+
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
-  
+
   <luceneMatchVersion>5.5.0</luceneMatchVersion>
 <!--
  <lib/> directives can be used to instruct Solr to load any Jars
@@ -17,20 +17,20 @@
        instanceDir.
 
        Please note that <lib/> directives are processed in the order
-       that they appear in your solrconfig.xml file, and are "stacked" 
-       on top of each other when building a ClassLoader - so if you have 
-       plugin jars with dependencies on other jars, the "lower level" 
+       that they appear in your solrconfig.xml file, and are "stacked"
+       on top of each other when building a ClassLoader - so if you have
+       plugin jars with dependencies on other jars, the "lower level"
        dependency jars should be loaded first.
 
        If a "./lib" directory exists in your instanceDir, all files
        found in it are included as if you had used the following
        syntax...
-       
+
               <lib dir="./lib" />
-    
+
 -->
 <!--
- A 'dir' option by itself adds any files found in the directory 
+ A 'dir' option by itself adds any files found in the directory
        to the classpath, this is useful for including all jars in a
        directory.
 
@@ -41,9 +41,9 @@
        If a 'dir' option (with or without a regex) is used and nothing
        is found that matches, a warning will be logged.
 
-       The examples below can be used to load some solr-contribs along 
+       The examples below can be used to load some solr-contribs along
        with their external dependencies.
-    
+
 -->
 <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar"/>
 <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar"/>
@@ -57,19 +57,19 @@
 <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" regex="lucene-analyzers-icu-\d.*\.jar"/>
 
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
-  
+
   <dataDir>${solr.data.dir:}</dataDir>
-  
+
   <indexConfig>
-    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a 
-         LimitTokenCountFilterFactory in your fieldType definition. E.g. 
+    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a
+         LimitTokenCountFilterFactory in your fieldType definition. E.g.
      <filter class="solr.LimitTokenCountFilterFactory" maxTokenCount="10000"/>
     -->
     <!-- Maximum time to wait for a write lock (ms) for an IndexWriter. Default: 1000 -->
     <!-- <writeLockTimeout>1000</writeLockTimeout>  -->
 
-    <!-- Expert: Enabling compound file will use less files for the index, 
-         using fewer file descriptors on the expense of performance decrease. 
+    <!-- Expert: Enabling compound file will use less files for the index,
+         using fewer file descriptors on the expense of performance decrease.
          Default in Lucene is "true". Default in Solr is "false" (since 3.6) -->
     <!-- <useCompoundFile>false</useCompoundFile> -->
 
@@ -84,7 +84,7 @@
     <!-- <ramBufferSizeMB>100</ramBufferSizeMB> -->
     <!-- <maxBufferedDocs>1000</maxBufferedDocs> -->
 
-    <!-- Expert: Merge Policy 
+    <!-- Expert: Merge Policy
          The Merge Policy in Lucene controls how merging of segments is done.
          The default since Solr/Lucene 3.3 is TieredMergePolicy.
          The default since Lucene 2.3 was the LogByteSizeMergePolicy,
@@ -104,15 +104,15 @@
          can perform merges in the background using separate threads.
          The SerialMergeScheduler (Lucene 2.2 default) does not.
      -->
-    <!-- 
+    <!--
        <mergeScheduler class="org.apache.lucene.index.ConcurrentMergeScheduler"/>
        -->
 
-    <!-- LockFactory 
+    <!-- LockFactory
 
          This option specifies which Lucene LockFactory implementation
          to use.
-      
+
          single = SingleInstanceLockFactory - suggested for a
                   read-only index or when there is no possibility of
                   another process trying to modify the index.
@@ -136,11 +136,11 @@
          The default Solr IndexDeletionPolicy implementation supports
          deleting index commit points on number of commits, age of
          commit point and optimized status.
-         
+
          The latest commit point should always be preserved regardless
          of the criteria.
     -->
-    <!-- 
+    <!--
     <deletionPolicy class="solr.SolrDeletionPolicy">
     -->
       <!-- The number of commit points to be kept -->
@@ -155,12 +155,12 @@
          <str name="maxCommitAge">30MINUTES</str>
          <str name="maxCommitAge">1DAY</str>
       -->
-    <!-- 
+    <!--
     </deletionPolicy>
     -->
 
     <!-- Lucene Infostream
-       
+
          To aid in advanced debugging, Lucene provides an "InfoStream"
          of detailed information when indexing.
 
@@ -186,7 +186,7 @@
        <float name="tie">0.01</float>
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the
-            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
             below, which the default blacklight_config will specify for
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
@@ -213,11 +213,14 @@
        </str>
        <str name="subject_pf">
        </str>
-       
+
        <str name="fl">
-         *, 
+         *,
          score
        </str>
+
+       <!-- set spell check to false to address blacklight auto-copying the q value to spellcheck.q -->
+       <str name="spellcheck">false</str>
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
@@ -227,7 +230,7 @@
        <str name="facet.field">object_type_sim</str>
        <str name="facet.field">collection_sim</str>
        <str name="facet.field">unit_sim</str>
-       
+
 	   <!-- configure for hit highlighting -->
 	   <str name="hl">true</str>
 	   <str name="hl.fl">content</str>
@@ -256,10 +259,10 @@
       </str>
     </lst>
   </requestHandler>
-  
+
   <requestHandler name="standard" class="solr.SearchHandler">
      <lst name="defaults">
-       
+
        <str name="echoParams">explicit</str>
        <str name="defType">lucene</str>
      </lst>
@@ -274,7 +277,7 @@
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
     </lst>
   </requestHandler>
- 
+
  <!-- Highlighting with FragListBuilder and boundaryScanner -->
   <searchComponent class="solr.HighlightComponent" name="highlight">
 	<highlighting>
@@ -289,7 +292,7 @@
    </searchComponent>
 
   <!-- replication master config -->
-  <requestHandler name="/replication" class="solr.ReplicationHandler"> 
+  <requestHandler name="/replication" class="solr.ReplicationHandler">
     <lst name="master">
       <str name="replicateAfter">startup</str>
       <str name="replicateAfter">commit</str>
@@ -305,11 +308,11 @@
     </lst>
   </requestHandler>
   -->
-  
+
   <requestDispatcher handleSelect="true" >
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
-  
+
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
   <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
   <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" />
@@ -325,7 +328,7 @@
              'soft' commit which only ensures that changes are visible
              but does not ensure that data is synced to disk.  This is
              faster and more near-realtime friendly than a hard commit.
-          
+
     -->
     <autoSoftCommit>
       <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
@@ -370,24 +373,24 @@
          is thrown if exceeded.
 
          ** WARNING **
-         
+
          This option actually modifies a global Lucene property that
          will affect all SolrCores.  If multiple solrconfig.xml files
          disagree on this property, the value at any given moment will
          be based on the last SolrCore to be initialized.
-         
+
       -->
     <maxBooleanClauses>1024</maxBooleanClauses>
 
- 
+
     <!-- Slow Query Threshold (in millis)
-    
-         At high request rates, logging all requests can become a bottleneck 
+
+         At high request rates, logging all requests can become a bottleneck
          and therefore INFO logging is often turned off. However, it is still
          useful to be able to set a latency threshold above which a request
          is considered "slow" and log that request at WARN level so we can
          easily identify slow queries.
-    --> 
+    -->
     <slowQueryThresholdMillis>-1</slowQueryThresholdMillis>
 
 
@@ -395,7 +398,7 @@
 
          There are two implementations of cache available for Solr,
          LRUCache, based on a synchronized LinkedHashMap, and
-         FastLRUCache, based on a ConcurrentHashMap.  
+         FastLRUCache, based on a ConcurrentHashMap.
 
          FastLRUCache has faster gets and slower puts in single
          threaded operation and thus is generally faster than LRUCache
@@ -420,7 +423,7 @@
            initialSize - the initial capacity (number of entries) of
                the cache.  (see java.util.HashMap)
            autowarmCount - the number of entries to prepopulate from
-               and old cache.  
+               and old cache.
       -->
     <filterCache class="solr.FastLRUCache"
                  size="512"
@@ -439,19 +442,19 @@
                      size="512"
                      initialSize="512"
                      autowarmCount="0"/>
-   
+
     <!-- Document Cache
 
          Caches Lucene Document objects (the stored fields for each
          document).  Since Lucene internal document ids are transient,
-         this cache will not be autowarmed.  
+         this cache will not be autowarmed.
       -->
     <documentCache class="solr.LRUCache"
                    size="512"
                    initialSize="512"
                    autowarmCount="0"/>
-    
-    <!-- custom cache currently used by block join --> 
+
+    <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
       class="solr.search.LRUCache"
       size="10"
@@ -460,7 +463,7 @@
       regenerator="solr.NoOpRegenerator" />
 
     <!-- Field Value Cache
-         
+
          Cache used to hold field values that are quickly accessible
          by document id.  The fieldValueCache is created by default
          even if not configured here.
@@ -478,8 +481,8 @@
          name through SolrIndexSearcher.getCache(),cacheLookup(), and
          cacheInsert().  The purpose is to enable easy caching of
          user/application level data.  The regenerator argument should
-         be specified as an implementation of solr.CacheRegenerator 
-         if autowarming is desired.  
+         be specified as an implementation of solr.CacheRegenerator
+         if autowarming is desired.
       -->
     <!--
        <cache name="myUserCache"
@@ -526,12 +529,12 @@
         are collected.  For example, if a search for a particular query
         requests matching documents 10 through 19, and queryWindowSize is 50,
         then documents 0 through 49 will be collected and cached.  Any further
-        requests in that range can be satisfied via the cache.  
+        requests in that range can be satisfied via the cache.
      -->
    <queryResultWindowSize>20</queryResultWindowSize>
 
    <!-- Maximum number of documents to cache for any entry in the
-        queryResultCache. 
+        queryResultCache.
      -->
    <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
@@ -549,10 +552,10 @@
         prepared but there is no current registered searcher to handle
         requests or to gain autowarming data from.
 
-        
+
      -->
     <!-- QuerySenderListener takes an array of NamedList and executes a
-         local query request for each NamedList in sequence. 
+         local query request for each NamedList in sequence.
       -->
     <listener event="newSearcher" class="solr.QuerySenderListener">
       <arr name="queries">
@@ -580,7 +583,7 @@
     <useColdSearcher>true</useColdSearcher>
 
     <!-- Max Warming Searchers
-         
+
          Maximum number of searchers that may be warming in the
          background concurrently.  An error is returned if this limit
          is exceeded.
@@ -644,8 +647,8 @@
 
   <!-- A request handler for demonstrating the clustering component.
        This is meant as an example.
-       In reality you will likely want to add the component to your 
-       already specified request handlers. 
+       In reality you will likely want to add the component to your
+       already specified request handlers.
     -->
   <requestHandler name="/clustering"
                   startup="lazy"
@@ -689,8 +692,8 @@
       <str name="echoParams">all</str>
     </lst>
   </requestHandler>
-  
-  <!-- config for the admin interface --> 
+
+  <!-- config for the admin interface -->
   <admin>
     <defaultQuery>search</defaultQuery>
   </admin>
@@ -698,7 +701,7 @@
 <!--
 
      Custom response writers can be declared as needed...
-    
+
 -->
 <queryResponseWriter name="velocity" class="solr.VelocityResponseWriter" startup="lazy">
 <str name="template.base.dir">${velocity.template.base.dir:velocity}</str>
@@ -706,8 +709,8 @@
 <!--
  XSLT response writer transforms the XML output by any xslt file found
        in Solr's conf/xslt directory.  Changes to xslt files are checked for
-       every xsltCacheLifetimeSeconds.  
-    
+       every xsltCacheLifetimeSeconds.
+
 -->
 <queryResponseWriter name="xslt" class="solr.XSLTResponseWriter">
 <int name="xsltCacheLifetimeSeconds">5</int>

--- a/qa-slave/conf/solrconfig.xml
+++ b/qa-slave/conf/solrconfig.xml
@@ -3,9 +3,9 @@
   <!-- NOTE: various comments and unused configuration possibilities have been purged
      from this file.  Please refer to http://wiki.apache.org/solr/SolrConfigXml,
      as well as the default solrconfig file included with Solr -->
-  
+
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
-  
+
   <luceneMatchVersion>5.5.0</luceneMatchVersion>
 <!--
  <lib/> directives can be used to instruct Solr to load any Jars
@@ -17,20 +17,20 @@
        instanceDir.
 
        Please note that <lib/> directives are processed in the order
-       that they appear in your solrconfig.xml file, and are "stacked" 
-       on top of each other when building a ClassLoader - so if you have 
-       plugin jars with dependencies on other jars, the "lower level" 
+       that they appear in your solrconfig.xml file, and are "stacked"
+       on top of each other when building a ClassLoader - so if you have
+       plugin jars with dependencies on other jars, the "lower level"
        dependency jars should be loaded first.
 
        If a "./lib" directory exists in your instanceDir, all files
        found in it are included as if you had used the following
        syntax...
-       
+
               <lib dir="./lib" />
-    
+
 -->
 <!--
- A 'dir' option by itself adds any files found in the directory 
+ A 'dir' option by itself adds any files found in the directory
        to the classpath, this is useful for including all jars in a
        directory.
 
@@ -41,9 +41,9 @@
        If a 'dir' option (with or without a regex) is used and nothing
        is found that matches, a warning will be logged.
 
-       The examples below can be used to load some solr-contribs along 
+       The examples below can be used to load some solr-contribs along
        with their external dependencies.
-    
+
 -->
 <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar"/>
 <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar"/>
@@ -57,19 +57,19 @@
 <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" regex="lucene-analyzers-icu-\d.*\.jar"/>
 
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
-  
+
   <dataDir>${solr.data.dir:}</dataDir>
-  
+
   <indexConfig>
-    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a 
-         LimitTokenCountFilterFactory in your fieldType definition. E.g. 
+    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a
+         LimitTokenCountFilterFactory in your fieldType definition. E.g.
      <filter class="solr.LimitTokenCountFilterFactory" maxTokenCount="10000"/>
     -->
     <!-- Maximum time to wait for a write lock (ms) for an IndexWriter. Default: 1000 -->
     <!-- <writeLockTimeout>1000</writeLockTimeout>  -->
 
-    <!-- Expert: Enabling compound file will use less files for the index, 
-         using fewer file descriptors on the expense of performance decrease. 
+    <!-- Expert: Enabling compound file will use less files for the index,
+         using fewer file descriptors on the expense of performance decrease.
          Default in Lucene is "true". Default in Solr is "false" (since 3.6) -->
     <!-- <useCompoundFile>false</useCompoundFile> -->
 
@@ -84,7 +84,7 @@
     <!-- <ramBufferSizeMB>100</ramBufferSizeMB> -->
     <!-- <maxBufferedDocs>1000</maxBufferedDocs> -->
 
-    <!-- Expert: Merge Policy 
+    <!-- Expert: Merge Policy
          The Merge Policy in Lucene controls how merging of segments is done.
          The default since Solr/Lucene 3.3 is TieredMergePolicy.
          The default since Lucene 2.3 was the LogByteSizeMergePolicy,
@@ -104,15 +104,15 @@
          can perform merges in the background using separate threads.
          The SerialMergeScheduler (Lucene 2.2 default) does not.
      -->
-    <!-- 
+    <!--
        <mergeScheduler class="org.apache.lucene.index.ConcurrentMergeScheduler"/>
        -->
 
-    <!-- LockFactory 
+    <!-- LockFactory
 
          This option specifies which Lucene LockFactory implementation
          to use.
-      
+
          single = SingleInstanceLockFactory - suggested for a
                   read-only index or when there is no possibility of
                   another process trying to modify the index.
@@ -136,11 +136,11 @@
          The default Solr IndexDeletionPolicy implementation supports
          deleting index commit points on number of commits, age of
          commit point and optimized status.
-         
+
          The latest commit point should always be preserved regardless
          of the criteria.
     -->
-    <!-- 
+    <!--
     <deletionPolicy class="solr.SolrDeletionPolicy">
     -->
       <!-- The number of commit points to be kept -->
@@ -155,12 +155,12 @@
          <str name="maxCommitAge">30MINUTES</str>
          <str name="maxCommitAge">1DAY</str>
       -->
-    <!-- 
+    <!--
     </deletionPolicy>
     -->
 
     <!-- Lucene Infostream
-       
+
          To aid in advanced debugging, Lucene provides an "InfoStream"
          of detailed information when indexing.
 
@@ -186,7 +186,7 @@
        <float name="tie">0.01</float>
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the
-            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
             below, which the default blacklight_config will specify for
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
@@ -213,11 +213,14 @@
        </str>
        <str name="subject_pf">
        </str>
-       
+
        <str name="fl">
-         *, 
+         *,
          score
        </str>
+
+       <!-- set spell check to false to address blacklight auto-copying the q value to spellcheck.q -->
+       <str name="spellcheck">false</str>
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
@@ -227,7 +230,7 @@
        <str name="facet.field">object_type_sim</str>
        <str name="facet.field">collection_sim</str>
        <str name="facet.field">unit_sim</str>
-       
+
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>
        <str name="spellcheck.dictionary">wordbreak</str>
@@ -237,7 +240,7 @@
        <str name="spellcheck.maxCollationTries">10</str>
        <str name="spellcheck.count">5</str>
        <str name="spellcheck.accuracy">0.7</str>
-       
+
 	   <!-- configure for hit highlighting -->
 	   <str name="hl">true</str>
 	   <str name="hl.fl">content</str>
@@ -269,10 +272,10 @@
       </str>
     </lst>
   </requestHandler>
-  
+
   <requestHandler name="standard" class="solr.SearchHandler">
      <lst name="defaults">
-       
+
        <str name="echoParams">explicit</str>
        <str name="defType">lucene</str>
      </lst>
@@ -287,7 +290,7 @@
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
     </lst>
   </requestHandler>
- 
+
  <!-- Highlighting with FragListBuilder and boundaryScanner -->
   <searchComponent class="solr.HighlightComponent" name="highlight">
 	<highlighting>
@@ -313,7 +316,7 @@
       <str name="buildOnOptimize">true</str>
       <str name="buildOnCommit">true</str>
     </lst>
-    
+
     <!-- a spellchecker that can break or combine words.  See "/spell" handler below for usage -->
 	<lst name="spellchecker">
 		<str name="name">wordbreak</str>
@@ -324,7 +327,7 @@
 		<int name="maxChanges">10</int>
 	</lst>
   </searchComponent>
-  
+
   <!-- replication slave config: -->
   <requestHandler name="/replication" class="solr.ReplicationHandler">
     <lst name="slave">
@@ -333,11 +336,11 @@
       <str name="pollInterval">00:00:60</str>
     </lst>
   </requestHandler>
-  
+
   <requestDispatcher handleSelect="true" >
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
-  
+
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
   <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
   <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" />
@@ -353,7 +356,7 @@
              'soft' commit which only ensures that changes are visible
              but does not ensure that data is synced to disk.  This is
              faster and more near-realtime friendly than a hard commit.
-          
+
     -->
     <autoSoftCommit>
       <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
@@ -398,24 +401,24 @@
          is thrown if exceeded.
 
          ** WARNING **
-         
+
          This option actually modifies a global Lucene property that
          will affect all SolrCores.  If multiple solrconfig.xml files
          disagree on this property, the value at any given moment will
          be based on the last SolrCore to be initialized.
-         
+
       -->
     <maxBooleanClauses>1024</maxBooleanClauses>
 
- 
+
     <!-- Slow Query Threshold (in millis)
-    
-         At high request rates, logging all requests can become a bottleneck 
+
+         At high request rates, logging all requests can become a bottleneck
          and therefore INFO logging is often turned off. However, it is still
          useful to be able to set a latency threshold above which a request
          is considered "slow" and log that request at WARN level so we can
          easily identify slow queries.
-    --> 
+    -->
     <slowQueryThresholdMillis>-1</slowQueryThresholdMillis>
 
 
@@ -423,7 +426,7 @@
 
          There are two implementations of cache available for Solr,
          LRUCache, based on a synchronized LinkedHashMap, and
-         FastLRUCache, based on a ConcurrentHashMap.  
+         FastLRUCache, based on a ConcurrentHashMap.
 
          FastLRUCache has faster gets and slower puts in single
          threaded operation and thus is generally faster than LRUCache
@@ -448,7 +451,7 @@
            initialSize - the initial capacity (number of entries) of
                the cache.  (see java.util.HashMap)
            autowarmCount - the number of entries to prepopulate from
-               and old cache.  
+               and old cache.
       -->
     <filterCache class="solr.FastLRUCache"
                  size="512"
@@ -467,19 +470,19 @@
                      size="512"
                      initialSize="512"
                      autowarmCount="0"/>
-   
+
     <!-- Document Cache
 
          Caches Lucene Document objects (the stored fields for each
          document).  Since Lucene internal document ids are transient,
-         this cache will not be autowarmed.  
+         this cache will not be autowarmed.
       -->
     <documentCache class="solr.LRUCache"
                    size="512"
                    initialSize="512"
                    autowarmCount="0"/>
-    
-    <!-- custom cache currently used by block join --> 
+
+    <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
       class="solr.search.LRUCache"
       size="10"
@@ -488,7 +491,7 @@
       regenerator="solr.NoOpRegenerator" />
 
     <!-- Field Value Cache
-         
+
          Cache used to hold field values that are quickly accessible
          by document id.  The fieldValueCache is created by default
          even if not configured here.
@@ -506,8 +509,8 @@
          name through SolrIndexSearcher.getCache(),cacheLookup(), and
          cacheInsert().  The purpose is to enable easy caching of
          user/application level data.  The regenerator argument should
-         be specified as an implementation of solr.CacheRegenerator 
-         if autowarming is desired.  
+         be specified as an implementation of solr.CacheRegenerator
+         if autowarming is desired.
       -->
     <!--
        <cache name="myUserCache"
@@ -554,12 +557,12 @@
         are collected.  For example, if a search for a particular query
         requests matching documents 10 through 19, and queryWindowSize is 50,
         then documents 0 through 49 will be collected and cached.  Any further
-        requests in that range can be satisfied via the cache.  
+        requests in that range can be satisfied via the cache.
      -->
    <queryResultWindowSize>20</queryResultWindowSize>
 
    <!-- Maximum number of documents to cache for any entry in the
-        queryResultCache. 
+        queryResultCache.
      -->
    <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
@@ -577,10 +580,10 @@
         prepared but there is no current registered searcher to handle
         requests or to gain autowarming data from.
 
-        
+
      -->
     <!-- QuerySenderListener takes an array of NamedList and executes a
-         local query request for each NamedList in sequence. 
+         local query request for each NamedList in sequence.
       -->
     <listener event="newSearcher" class="solr.QuerySenderListener">
       <arr name="queries">
@@ -608,7 +611,7 @@
     <useColdSearcher>true</useColdSearcher>
 
     <!-- Max Warming Searchers
-         
+
          Maximum number of searchers that may be warming in the
          background concurrently.  An error is returned if this limit
          is exceeded.
@@ -672,8 +675,8 @@
 
   <!-- A request handler for demonstrating the clustering component.
        This is meant as an example.
-       In reality you will likely want to add the component to your 
-       already specified request handlers. 
+       In reality you will likely want to add the component to your
+       already specified request handlers.
     -->
   <requestHandler name="/clustering"
                   startup="lazy"
@@ -717,8 +720,8 @@
       <str name="echoParams">all</str>
     </lst>
   </requestHandler>
-  
-  <!-- config for the admin interface --> 
+
+  <!-- config for the admin interface -->
   <admin>
     <defaultQuery>search</defaultQuery>
   </admin>
@@ -726,7 +729,7 @@
 <!--
 
      Custom response writers can be declared as needed...
-    
+
 -->
 <queryResponseWriter name="velocity" class="solr.VelocityResponseWriter" startup="lazy">
 <str name="template.base.dir">${velocity.template.base.dir:velocity}</str>
@@ -734,8 +737,8 @@
 <!--
  XSLT response writer transforms the XML output by any xslt file found
        in Solr's conf/xslt directory.  Changes to xslt files are checked for
-       every xsltCacheLifetimeSeconds.  
-    
+       every xsltCacheLifetimeSeconds.
+
 -->
 <queryResponseWriter name="xslt" class="solr.XSLTResponseWriter">
 <int name="xsltCacheLifetimeSeconds">5</int>

--- a/qa/conf/solrconfig.xml
+++ b/qa/conf/solrconfig.xml
@@ -3,9 +3,9 @@
   <!-- NOTE: various comments and unused configuration possibilities have been purged
      from this file.  Please refer to http://wiki.apache.org/solr/SolrConfigXml,
      as well as the default solrconfig file included with Solr -->
-  
+
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
-  
+
   <luceneMatchVersion>5.5.0</luceneMatchVersion>
 <!--
  <lib/> directives can be used to instruct Solr to load any Jars
@@ -17,20 +17,20 @@
        instanceDir.
 
        Please note that <lib/> directives are processed in the order
-       that they appear in your solrconfig.xml file, and are "stacked" 
-       on top of each other when building a ClassLoader - so if you have 
-       plugin jars with dependencies on other jars, the "lower level" 
+       that they appear in your solrconfig.xml file, and are "stacked"
+       on top of each other when building a ClassLoader - so if you have
+       plugin jars with dependencies on other jars, the "lower level"
        dependency jars should be loaded first.
 
        If a "./lib" directory exists in your instanceDir, all files
        found in it are included as if you had used the following
        syntax...
-       
+
               <lib dir="./lib" />
-    
+
 -->
 <!--
- A 'dir' option by itself adds any files found in the directory 
+ A 'dir' option by itself adds any files found in the directory
        to the classpath, this is useful for including all jars in a
        directory.
 
@@ -41,9 +41,9 @@
        If a 'dir' option (with or without a regex) is used and nothing
        is found that matches, a warning will be logged.
 
-       The examples below can be used to load some solr-contribs along 
+       The examples below can be used to load some solr-contribs along
        with their external dependencies.
-    
+
 -->
 <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar"/>
 <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar"/>
@@ -57,19 +57,19 @@
 <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" regex="lucene-analyzers-icu-\d.*\.jar"/>
 
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
-  
+
   <dataDir>${solr.data.dir:}</dataDir>
-  
+
   <indexConfig>
-    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a 
-         LimitTokenCountFilterFactory in your fieldType definition. E.g. 
+    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a
+         LimitTokenCountFilterFactory in your fieldType definition. E.g.
      <filter class="solr.LimitTokenCountFilterFactory" maxTokenCount="10000"/>
     -->
     <!-- Maximum time to wait for a write lock (ms) for an IndexWriter. Default: 1000 -->
     <!-- <writeLockTimeout>1000</writeLockTimeout>  -->
 
-    <!-- Expert: Enabling compound file will use less files for the index, 
-         using fewer file descriptors on the expense of performance decrease. 
+    <!-- Expert: Enabling compound file will use less files for the index,
+         using fewer file descriptors on the expense of performance decrease.
          Default in Lucene is "true". Default in Solr is "false" (since 3.6) -->
     <!-- <useCompoundFile>false</useCompoundFile> -->
 
@@ -84,7 +84,7 @@
     <!-- <ramBufferSizeMB>100</ramBufferSizeMB> -->
     <!-- <maxBufferedDocs>1000</maxBufferedDocs> -->
 
-    <!-- Expert: Merge Policy 
+    <!-- Expert: Merge Policy
          The Merge Policy in Lucene controls how merging of segments is done.
          The default since Solr/Lucene 3.3 is TieredMergePolicy.
          The default since Lucene 2.3 was the LogByteSizeMergePolicy,
@@ -104,15 +104,15 @@
          can perform merges in the background using separate threads.
          The SerialMergeScheduler (Lucene 2.2 default) does not.
      -->
-    <!-- 
+    <!--
        <mergeScheduler class="org.apache.lucene.index.ConcurrentMergeScheduler"/>
        -->
 
-    <!-- LockFactory 
+    <!-- LockFactory
 
          This option specifies which Lucene LockFactory implementation
          to use.
-      
+
          single = SingleInstanceLockFactory - suggested for a
                   read-only index or when there is no possibility of
                   another process trying to modify the index.
@@ -136,11 +136,11 @@
          The default Solr IndexDeletionPolicy implementation supports
          deleting index commit points on number of commits, age of
          commit point and optimized status.
-         
+
          The latest commit point should always be preserved regardless
          of the criteria.
     -->
-    <!-- 
+    <!--
     <deletionPolicy class="solr.SolrDeletionPolicy">
     -->
       <!-- The number of commit points to be kept -->
@@ -155,12 +155,12 @@
          <str name="maxCommitAge">30MINUTES</str>
          <str name="maxCommitAge">1DAY</str>
       -->
-    <!-- 
+    <!--
     </deletionPolicy>
     -->
 
     <!-- Lucene Infostream
-       
+
          To aid in advanced debugging, Lucene provides an "InfoStream"
          of detailed information when indexing.
 
@@ -186,7 +186,7 @@
        <float name="tie">0.01</float>
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the
-            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
             below, which the default blacklight_config will specify for
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
@@ -213,11 +213,14 @@
        </str>
        <str name="subject_pf">
        </str>
-       
+
        <str name="fl">
-         *, 
+         *,
          score
        </str>
+
+       <!-- set spell check to false to address blacklight auto-copying the q value to spellcheck.q -->
+       <str name="spellcheck">false</str>
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
@@ -227,7 +230,7 @@
        <str name="facet.field">object_type_sim</str>
        <str name="facet.field">collection_sim</str>
        <str name="facet.field">unit_sim</str>
-       
+
 	   <!-- configure for hit highlighting -->
 	   <str name="hl">true</str>
 	   <str name="hl.fl">content</str>
@@ -256,10 +259,10 @@
       </str>
     </lst>
   </requestHandler>
-  
+
   <requestHandler name="standard" class="solr.SearchHandler">
      <lst name="defaults">
-       
+
        <str name="echoParams">explicit</str>
        <str name="defType">lucene</str>
      </lst>
@@ -274,7 +277,7 @@
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
     </lst>
   </requestHandler>
- 
+
  <!-- Highlighting with FragListBuilder and boundaryScanner -->
   <searchComponent class="solr.HighlightComponent" name="highlight">
 	<highlighting>
@@ -289,7 +292,7 @@
    </searchComponent>
 
   <!-- replication master config -->
-  <requestHandler name="/replication" class="solr.ReplicationHandler"> 
+  <requestHandler name="/replication" class="solr.ReplicationHandler">
     <lst name="master">
       <str name="replicateAfter">startup</str>
       <str name="replicateAfter">commit</str>
@@ -305,11 +308,11 @@
     </lst>
   </requestHandler>
   -->
-  
+
   <requestDispatcher handleSelect="true" >
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
-  
+
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
   <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
   <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" />
@@ -325,7 +328,7 @@
              'soft' commit which only ensures that changes are visible
              but does not ensure that data is synced to disk.  This is
              faster and more near-realtime friendly than a hard commit.
-          
+
     -->
     <autoSoftCommit>
       <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
@@ -370,24 +373,24 @@
          is thrown if exceeded.
 
          ** WARNING **
-         
+
          This option actually modifies a global Lucene property that
          will affect all SolrCores.  If multiple solrconfig.xml files
          disagree on this property, the value at any given moment will
          be based on the last SolrCore to be initialized.
-         
+
       -->
     <maxBooleanClauses>1024</maxBooleanClauses>
 
- 
+
     <!-- Slow Query Threshold (in millis)
-    
-         At high request rates, logging all requests can become a bottleneck 
+
+         At high request rates, logging all requests can become a bottleneck
          and therefore INFO logging is often turned off. However, it is still
          useful to be able to set a latency threshold above which a request
          is considered "slow" and log that request at WARN level so we can
          easily identify slow queries.
-    --> 
+    -->
     <slowQueryThresholdMillis>-1</slowQueryThresholdMillis>
 
 
@@ -395,7 +398,7 @@
 
          There are two implementations of cache available for Solr,
          LRUCache, based on a synchronized LinkedHashMap, and
-         FastLRUCache, based on a ConcurrentHashMap.  
+         FastLRUCache, based on a ConcurrentHashMap.
 
          FastLRUCache has faster gets and slower puts in single
          threaded operation and thus is generally faster than LRUCache
@@ -420,7 +423,7 @@
            initialSize - the initial capacity (number of entries) of
                the cache.  (see java.util.HashMap)
            autowarmCount - the number of entries to prepopulate from
-               and old cache.  
+               and old cache.
       -->
     <filterCache class="solr.FastLRUCache"
                  size="512"
@@ -439,19 +442,19 @@
                      size="512"
                      initialSize="512"
                      autowarmCount="0"/>
-   
+
     <!-- Document Cache
 
          Caches Lucene Document objects (the stored fields for each
          document).  Since Lucene internal document ids are transient,
-         this cache will not be autowarmed.  
+         this cache will not be autowarmed.
       -->
     <documentCache class="solr.LRUCache"
                    size="512"
                    initialSize="512"
                    autowarmCount="0"/>
-    
-    <!-- custom cache currently used by block join --> 
+
+    <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
       class="solr.search.LRUCache"
       size="10"
@@ -460,7 +463,7 @@
       regenerator="solr.NoOpRegenerator" />
 
     <!-- Field Value Cache
-         
+
          Cache used to hold field values that are quickly accessible
          by document id.  The fieldValueCache is created by default
          even if not configured here.
@@ -478,8 +481,8 @@
          name through SolrIndexSearcher.getCache(),cacheLookup(), and
          cacheInsert().  The purpose is to enable easy caching of
          user/application level data.  The regenerator argument should
-         be specified as an implementation of solr.CacheRegenerator 
-         if autowarming is desired.  
+         be specified as an implementation of solr.CacheRegenerator
+         if autowarming is desired.
       -->
     <!--
        <cache name="myUserCache"
@@ -526,12 +529,12 @@
         are collected.  For example, if a search for a particular query
         requests matching documents 10 through 19, and queryWindowSize is 50,
         then documents 0 through 49 will be collected and cached.  Any further
-        requests in that range can be satisfied via the cache.  
+        requests in that range can be satisfied via the cache.
      -->
    <queryResultWindowSize>20</queryResultWindowSize>
 
    <!-- Maximum number of documents to cache for any entry in the
-        queryResultCache. 
+        queryResultCache.
      -->
    <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
@@ -549,10 +552,10 @@
         prepared but there is no current registered searcher to handle
         requests or to gain autowarming data from.
 
-        
+
      -->
     <!-- QuerySenderListener takes an array of NamedList and executes a
-         local query request for each NamedList in sequence. 
+         local query request for each NamedList in sequence.
       -->
     <listener event="newSearcher" class="solr.QuerySenderListener">
       <arr name="queries">
@@ -580,7 +583,7 @@
     <useColdSearcher>true</useColdSearcher>
 
     <!-- Max Warming Searchers
-         
+
          Maximum number of searchers that may be warming in the
          background concurrently.  An error is returned if this limit
          is exceeded.
@@ -644,8 +647,8 @@
 
   <!-- A request handler for demonstrating the clustering component.
        This is meant as an example.
-       In reality you will likely want to add the component to your 
-       already specified request handlers. 
+       In reality you will likely want to add the component to your
+       already specified request handlers.
     -->
   <requestHandler name="/clustering"
                   startup="lazy"
@@ -689,8 +692,8 @@
       <str name="echoParams">all</str>
     </lst>
   </requestHandler>
-  
-  <!-- config for the admin interface --> 
+
+  <!-- config for the admin interface -->
   <admin>
     <defaultQuery>search</defaultQuery>
   </admin>
@@ -698,7 +701,7 @@
 <!--
 
      Custom response writers can be declared as needed...
-    
+
 -->
 <queryResponseWriter name="velocity" class="solr.VelocityResponseWriter" startup="lazy">
 <str name="template.base.dir">${velocity.template.base.dir:velocity}</str>
@@ -706,8 +709,8 @@
 <!--
  XSLT response writer transforms the XML output by any xslt file found
        in Solr's conf/xslt directory.  Changes to xslt files are checked for
-       every xsltCacheLifetimeSeconds.  
-    
+       every xsltCacheLifetimeSeconds.
+
 -->
 <queryResponseWriter name="xslt" class="solr.XSLTResponseWriter">
 <int name="xsltCacheLifetimeSeconds">5</int>

--- a/staging/conf/solrconfig.xml
+++ b/staging/conf/solrconfig.xml
@@ -3,9 +3,9 @@
   <!-- NOTE: various comments and unused configuration possibilities have been purged
      from this file.  Please refer to http://wiki.apache.org/solr/SolrConfigXml,
      as well as the default solrconfig file included with Solr -->
-  
+
   <abortOnConfigurationError>${solr.abortOnConfigurationError:true}</abortOnConfigurationError>
-  
+
   <luceneMatchVersion>5.5.0</luceneMatchVersion>
 <!--
  <lib/> directives can be used to instruct Solr to load any Jars
@@ -17,20 +17,20 @@
        instanceDir.
 
        Please note that <lib/> directives are processed in the order
-       that they appear in your solrconfig.xml file, and are "stacked" 
-       on top of each other when building a ClassLoader - so if you have 
-       plugin jars with dependencies on other jars, the "lower level" 
+       that they appear in your solrconfig.xml file, and are "stacked"
+       on top of each other when building a ClassLoader - so if you have
+       plugin jars with dependencies on other jars, the "lower level"
        dependency jars should be loaded first.
 
        If a "./lib" directory exists in your instanceDir, all files
        found in it are included as if you had used the following
        syntax...
-       
+
               <lib dir="./lib" />
-    
+
 -->
 <!--
- A 'dir' option by itself adds any files found in the directory 
+ A 'dir' option by itself adds any files found in the directory
        to the classpath, this is useful for including all jars in a
        directory.
 
@@ -41,9 +41,9 @@
        If a 'dir' option (with or without a regex) is used and nothing
        is found that matches, a warning will be logged.
 
-       The examples below can be used to load some solr-contribs along 
+       The examples below can be used to load some solr-contribs along
        with their external dependencies.
-    
+
 -->
 <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar"/>
 <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar"/>
@@ -57,19 +57,19 @@
 <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" regex="lucene-analyzers-icu-\d.*\.jar"/>
 
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
-  
+
   <dataDir>${solr.data.dir:}</dataDir>
-  
+
   <indexConfig>
-    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a 
-         LimitTokenCountFilterFactory in your fieldType definition. E.g. 
+    <!-- maxFieldLength was removed in 4.0. To get similar behavior, include a
+         LimitTokenCountFilterFactory in your fieldType definition. E.g.
      <filter class="solr.LimitTokenCountFilterFactory" maxTokenCount="10000"/>
     -->
     <!-- Maximum time to wait for a write lock (ms) for an IndexWriter. Default: 1000 -->
     <!-- <writeLockTimeout>1000</writeLockTimeout>  -->
 
-    <!-- Expert: Enabling compound file will use less files for the index, 
-         using fewer file descriptors on the expense of performance decrease. 
+    <!-- Expert: Enabling compound file will use less files for the index,
+         using fewer file descriptors on the expense of performance decrease.
          Default in Lucene is "true". Default in Solr is "false" (since 3.6) -->
     <!-- <useCompoundFile>false</useCompoundFile> -->
 
@@ -84,7 +84,7 @@
     <!-- <ramBufferSizeMB>100</ramBufferSizeMB> -->
     <!-- <maxBufferedDocs>1000</maxBufferedDocs> -->
 
-    <!-- Expert: Merge Policy 
+    <!-- Expert: Merge Policy
          The Merge Policy in Lucene controls how merging of segments is done.
          The default since Solr/Lucene 3.3 is TieredMergePolicy.
          The default since Lucene 2.3 was the LogByteSizeMergePolicy,
@@ -104,15 +104,15 @@
          can perform merges in the background using separate threads.
          The SerialMergeScheduler (Lucene 2.2 default) does not.
      -->
-    <!-- 
+    <!--
        <mergeScheduler class="org.apache.lucene.index.ConcurrentMergeScheduler"/>
        -->
 
-    <!-- LockFactory 
+    <!-- LockFactory
 
          This option specifies which Lucene LockFactory implementation
          to use.
-      
+
          single = SingleInstanceLockFactory - suggested for a
                   read-only index or when there is no possibility of
                   another process trying to modify the index.
@@ -136,11 +136,11 @@
          The default Solr IndexDeletionPolicy implementation supports
          deleting index commit points on number of commits, age of
          commit point and optimized status.
-         
+
          The latest commit point should always be preserved regardless
          of the criteria.
     -->
-    <!-- 
+    <!--
     <deletionPolicy class="solr.SolrDeletionPolicy">
     -->
       <!-- The number of commit points to be kept -->
@@ -155,12 +155,12 @@
          <str name="maxCommitAge">30MINUTES</str>
          <str name="maxCommitAge">1DAY</str>
       -->
-    <!-- 
+    <!--
     </deletionPolicy>
     -->
 
     <!-- Lucene Infostream
-       
+
          To aid in advanced debugging, Lucene provides an "InfoStream"
          of detailed information when indexing.
 
@@ -186,7 +186,7 @@
        <float name="tie">0.01</float>
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the
-            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
             below, which the default blacklight_config will specify for
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
@@ -213,11 +213,14 @@
        </str>
        <str name="subject_pf">
        </str>
-       
+
        <str name="fl">
-         *, 
+         *,
          score
        </str>
+
+       <!-- set spell check to false to address blacklight auto-copying the q value to spellcheck.q -->
+       <str name="spellcheck">false</str>
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
@@ -227,7 +230,7 @@
        <str name="facet.field">object_type_sim</str>
        <str name="facet.field">collection_sim</str>
        <str name="facet.field">unit_sim</str>
-       
+
 	   <!-- configure for hit highlighting -->
 	   <str name="hl">true</str>
 	   <str name="hl.fl">content</str>
@@ -256,10 +259,10 @@
       </str>
     </lst>
   </requestHandler>
-  
+
   <requestHandler name="standard" class="solr.SearchHandler">
      <lst name="defaults">
-       
+
        <str name="echoParams">explicit</str>
        <str name="defType">lucene</str>
      </lst>
@@ -274,7 +277,7 @@
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
     </lst>
   </requestHandler>
- 
+
  <!-- Highlighting with FragListBuilder and boundaryScanner -->
   <searchComponent class="solr.HighlightComponent" name="highlight">
 	<highlighting>
@@ -289,7 +292,7 @@
    </searchComponent>
 
   <!-- replication master config -->
-  <requestHandler name="/replication" class="solr.ReplicationHandler"> 
+  <requestHandler name="/replication" class="solr.ReplicationHandler">
     <lst name="master">
       <str name="replicateAfter">startup</str>
       <str name="replicateAfter">commit</str>
@@ -305,11 +308,11 @@
     </lst>
   </requestHandler>
   -->
-  
+
   <requestDispatcher handleSelect="true" >
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
-  
+
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
   <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
   <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" />
@@ -325,7 +328,7 @@
              'soft' commit which only ensures that changes are visible
              but does not ensure that data is synced to disk.  This is
              faster and more near-realtime friendly than a hard commit.
-          
+
     -->
     <autoSoftCommit>
       <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
@@ -370,24 +373,24 @@
          is thrown if exceeded.
 
          ** WARNING **
-         
+
          This option actually modifies a global Lucene property that
          will affect all SolrCores.  If multiple solrconfig.xml files
          disagree on this property, the value at any given moment will
          be based on the last SolrCore to be initialized.
-         
+
       -->
     <maxBooleanClauses>1024</maxBooleanClauses>
 
- 
+
     <!-- Slow Query Threshold (in millis)
-    
-         At high request rates, logging all requests can become a bottleneck 
+
+         At high request rates, logging all requests can become a bottleneck
          and therefore INFO logging is often turned off. However, it is still
          useful to be able to set a latency threshold above which a request
          is considered "slow" and log that request at WARN level so we can
          easily identify slow queries.
-    --> 
+    -->
     <slowQueryThresholdMillis>-1</slowQueryThresholdMillis>
 
 
@@ -395,7 +398,7 @@
 
          There are two implementations of cache available for Solr,
          LRUCache, based on a synchronized LinkedHashMap, and
-         FastLRUCache, based on a ConcurrentHashMap.  
+         FastLRUCache, based on a ConcurrentHashMap.
 
          FastLRUCache has faster gets and slower puts in single
          threaded operation and thus is generally faster than LRUCache
@@ -420,7 +423,7 @@
            initialSize - the initial capacity (number of entries) of
                the cache.  (see java.util.HashMap)
            autowarmCount - the number of entries to prepopulate from
-               and old cache.  
+               and old cache.
       -->
     <filterCache class="solr.FastLRUCache"
                  size="512"
@@ -439,19 +442,19 @@
                      size="512"
                      initialSize="512"
                      autowarmCount="0"/>
-   
+
     <!-- Document Cache
 
          Caches Lucene Document objects (the stored fields for each
          document).  Since Lucene internal document ids are transient,
-         this cache will not be autowarmed.  
+         this cache will not be autowarmed.
       -->
     <documentCache class="solr.LRUCache"
                    size="512"
                    initialSize="512"
                    autowarmCount="0"/>
-    
-    <!-- custom cache currently used by block join --> 
+
+    <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
       class="solr.search.LRUCache"
       size="10"
@@ -460,7 +463,7 @@
       regenerator="solr.NoOpRegenerator" />
 
     <!-- Field Value Cache
-         
+
          Cache used to hold field values that are quickly accessible
          by document id.  The fieldValueCache is created by default
          even if not configured here.
@@ -478,8 +481,8 @@
          name through SolrIndexSearcher.getCache(),cacheLookup(), and
          cacheInsert().  The purpose is to enable easy caching of
          user/application level data.  The regenerator argument should
-         be specified as an implementation of solr.CacheRegenerator 
-         if autowarming is desired.  
+         be specified as an implementation of solr.CacheRegenerator
+         if autowarming is desired.
       -->
     <!--
        <cache name="myUserCache"
@@ -526,12 +529,12 @@
         are collected.  For example, if a search for a particular query
         requests matching documents 10 through 19, and queryWindowSize is 50,
         then documents 0 through 49 will be collected and cached.  Any further
-        requests in that range can be satisfied via the cache.  
+        requests in that range can be satisfied via the cache.
      -->
    <queryResultWindowSize>20</queryResultWindowSize>
 
    <!-- Maximum number of documents to cache for any entry in the
-        queryResultCache. 
+        queryResultCache.
      -->
    <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
@@ -549,10 +552,10 @@
         prepared but there is no current registered searcher to handle
         requests or to gain autowarming data from.
 
-        
+
      -->
     <!-- QuerySenderListener takes an array of NamedList and executes a
-         local query request for each NamedList in sequence. 
+         local query request for each NamedList in sequence.
       -->
     <listener event="newSearcher" class="solr.QuerySenderListener">
       <arr name="queries">
@@ -580,7 +583,7 @@
     <useColdSearcher>true</useColdSearcher>
 
     <!-- Max Warming Searchers
-         
+
          Maximum number of searchers that may be warming in the
          background concurrently.  An error is returned if this limit
          is exceeded.
@@ -644,8 +647,8 @@
 
   <!-- A request handler for demonstrating the clustering component.
        This is meant as an example.
-       In reality you will likely want to add the component to your 
-       already specified request handlers. 
+       In reality you will likely want to add the component to your
+       already specified request handlers.
     -->
   <requestHandler name="/clustering"
                   startup="lazy"
@@ -689,8 +692,8 @@
       <str name="echoParams">all</str>
     </lst>
   </requestHandler>
-  
-  <!-- config for the admin interface --> 
+
+  <!-- config for the admin interface -->
   <admin>
     <defaultQuery>search</defaultQuery>
   </admin>
@@ -698,7 +701,7 @@
 <!--
 
      Custom response writers can be declared as needed...
-    
+
 -->
 <queryResponseWriter name="velocity" class="solr.VelocityResponseWriter" startup="lazy">
 <str name="template.base.dir">${velocity.template.base.dir:velocity}</str>
@@ -706,8 +709,8 @@
 <!--
  XSLT response writer transforms the XML output by any xslt file found
        in Solr's conf/xslt directory.  Changes to xslt files are checked for
-       every xsltCacheLifetimeSeconds.  
-    
+       every xsltCacheLifetimeSeconds.
+
 -->
 <queryResponseWriter name="xslt" class="solr.XSLTResponseWriter">
 <int name="xsltCacheLifetimeSeconds">5</int>


### PR DESCRIPTION
Unfortunately when custom solr parameters are passed to the blacklight
get_search_results function, it overrides some of the sane defaults that
are set. One, notably, is setting spellcheck to false. Because this
isn't specified, and blacklight also automatically sets spellcheck.q to
be the value of q, we get errors now that we have spellcheck disabled.

I'm hoping this will do the trick. The alternative is I'll need to go through every single damspas query to `get_search_results` and explicitly set spellcheck to false.. which would be less than fun. Hopefully this will work, but we need to test.